### PR TITLE
Added pre commit hook for requirements.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,12 @@ repos:
     -   id: ruff
         args: [--fix]
     -   id: ruff-format
+
+-   repo: local
+    hooks:
+    -   id: update-requirements
+        name: Update requirements.txt with pipreqs
+        entry: pipreqs .
+        language: system
+        pass_filenames: false
+        args: ["--force"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 invoke==2.2.0
+kagglehub==0.3.6
 torch==2.5.1
 typer==0.15.1


### PR DESCRIPTION
This pull request includes an update to the `.pre-commit-config.yaml` file to add a new local hook for updating `requirements.txt` using `pipreqs`.

Changes to `.pre-commit-config.yaml`:

* Added a new local hook to update `requirements.txt` with `pipreqs`. The hook is configured to run the `pipreqs .` command with the `--force` argument, and it does not pass filenames.