### PR TITLE
Data version control

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,5 @@
+[core]
+    remote = remote_storage
+['remote "remote_storage"']
+    url = gs://chromify_bucket/
+    version_aware = true

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/data/raw/.gitignore
+++ b/data/raw/.gitignore
@@ -1,0 +1,1 @@
+/raw_archive.zip

--- a/data/raw/raw_archive.zip.dvc
+++ b/data/raw/raw_archive.zip.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: fd2f89ff7b4a90e748db52022b8d30e1
+  size: 3159147920
+  hash: md5
+  path: raw_archive.zip

--- a/data/raw/raw_archive.zip.dvc
+++ b/data/raw/raw_archive.zip.dvc
@@ -3,3 +3,7 @@ outs:
   size: 3159147920
   hash: md5
   path: raw_archive.zip
+  cloud:
+    remote_storage:
+      etag: 08bee4d5f587f68a031001
+      version_id: '1736886900322878'


### PR DESCRIPTION
# Add Data Version Control (DVC) to the Project

This pull request adds Data Version Control (DVC) to the project.  
In theory, this was not strictly necessary since we downloaded the data from Kaggle. However, it has been implemented to showcase our understanding of data version control and how to integrate it into a project.

## Pushing and Pulling from Google Cloud (GC)

To push and pull data from Google Cloud, authentication is required. Follow these steps:

1. Obtain the key file in JSON format from the **Service Account** named `storage`.
2. Add the key file path to your Conda environment variables using the following command:

   ```bash
   conda env config vars set GOOGLE_APPLICATION_CREDENTIALS="path/to/your/keyfile.json"
